### PR TITLE
Support for xmldom.

### DIFF
--- a/src/strophe.caps.js
+++ b/src/strophe.caps.js
@@ -129,7 +129,7 @@ import 'strophejs-plugin-disco';
 	 */
 	_delegateCapabilities: function(stanza) {
 		var from = stanza.getAttribute('from'),
-			c = stanza.querySelector('c'),
+			c = stanza.getElementsByTagName('c')[0],
 			ver = c.getAttribute('ver'),
 			node = c.getAttribute('node');
 		if (!this._knownCapabilities[ver]) {
@@ -176,7 +176,7 @@ import 'strophejs-plugin-disco';
 	 *   (Boolean) - false, to automatically remove the handler.
 	 */
 	_handleDiscoInfoReply: function(stanza) {
-		var query = stanza.querySelector('query'),
+		var query = stanza.stanza.getElementsByTagName('query')[0],
 			node = query.getAttribute('node').split('#'),
 			ver = node[1],
 			from = stanza.getAttribute('from');

--- a/src/strophe.caps.js
+++ b/src/strophe.caps.js
@@ -176,7 +176,7 @@ import 'strophejs-plugin-disco';
 	 *   (Boolean) - false, to automatically remove the handler.
 	 */
 	_handleDiscoInfoReply: function(stanza) {
-		var query = stanza.stanza.getElementsByTagName('query')[0],
+		var query = stanza.getElementsByTagName('query')[0],
 			node = query.getAttribute('node').split('#'),
 			ver = node[1],
 			from = stanza.getAttribute('from');


### PR DESCRIPTION
Trying to use this plugin outside of a browser with `xmldom` (for React-Native), it did not work as `querySelector` was not defined.

I've looked at the cases where `querySelector` was used and it can easily be replace with a call to `getElementsByTagName(tagName)[0]` call.

Using the later would make it work both on web and node environments.